### PR TITLE
Cosmetic fixes + Target more recent NEMO with BN calibration

### DIFF
--- a/PyTorch/ModelManager.py
+++ b/PyTorch/ModelManager.py
@@ -45,7 +45,10 @@ class ModelManager:
 
         state_dict = torch.load(filename, map_location='cpu')
         epoch = state_dict['epoch']
-        prec_dict = state_dict['precision']
+        try:
+            prec_dict = state_dict['precision']
+        except KeyError:
+            prec_dict = None
 
         try:
             model.load_state_dict(state_dict['state_dict'], strict=True)

--- a/PyTorch/quant.sh
+++ b/PyTorch/quant.sh
@@ -6,5 +6,6 @@
 #
 # This script runs a full precision training example
 
-CUDA_VISIBLE_DEVICES= python3 ETHQuantize2.py --regime regime.json --epochs 10 --gray 1 --load-trainset "/Users/usi/PycharmProjects/data/160x96/160x96HimaxMixedTrain_12_03_20AugCrop.pickle" --load-model "Models/checkpoint_current_best.pth" --quantiz --save-model "HannaNetQ.pt"
+mkdir -p PenguiNet/golden
+CUDA_VISIBLE_DEVICES=2 python3 ETHQuantize.py --regime regime.json --epochs 100 --gray 1 --load-trainset "/home/nickyz/data/160x96HimaxMixedTrain_12_03_20AugCrop.pickle" --load-model "PenguiNetQ.pt" --quantize --save-model "PenguiNetQ2.pt"
 


### PR DESCRIPTION
Most of the fixes are cosmetic (e.g., remove FC bias from ONNX, put an output_dequant.txt file with instructions on how to derive the real values from the quantized outputs). Additionally, we move to NEMO v0.0.7 which should help significantly with using pure 32-bit accumulators (as supported in DORY / GAP8), using BN calibration and other techniques.